### PR TITLE
Unity 2022.1+ Support (Fixing Render Features)

### DIFF
--- a/URP-PSX/Assets/Scripts/Dithering/DitheringRenderFeature.cs
+++ b/URP-PSX/Assets/Scripts/Dithering/DitheringRenderFeature.cs
@@ -13,15 +13,23 @@ namespace PSX
             ditheringPass = new DitheringPass(RenderPassEvent.BeforeRenderingPostProcessing);
         }
 
+#if UNITY_2022_1_OR_NEWER
+        public override void SetupRenderPasses(ScriptableRenderer renderer, in RenderingData renderingData)
+        { ditheringPass.Setup(renderer.cameraColorTargetHandle); }
+#endif
+
         //ScripstableRendererFeature is an abstract class, you need this method
         public override void AddRenderPasses(ScriptableRenderer renderer, ref RenderingData renderingData)
         {
+#if !UNITY_2022_1_OR_NEWER
             ditheringPass.Setup(renderer.cameraColorTarget);
+#endif
+
             renderer.EnqueuePass(ditheringPass);
         }
     }
-    
-    
+
+
     public class DitheringPass : ScriptableRenderPass
     {
         private static readonly string shaderPath = "PostEffect/Dithering";

--- a/URP-PSX/Assets/Scripts/Fog/FogRenderFeature.cs
+++ b/URP-PSX/Assets/Scripts/Fog/FogRenderFeature.cs
@@ -13,15 +13,23 @@ namespace PSX
             fogPass = new FogPass(RenderPassEvent.BeforeRenderingPostProcessing);
         }
 
+#if UNITY_2022_1_OR_NEWER
+        public override void SetupRenderPasses(ScriptableRenderer renderer, in RenderingData renderingData)
+        { fogPass.Setup(renderer.cameraColorTargetHandle); }
+#endif
+
         //ScripstableRendererFeature is an abstract class, you need this method
         public override void AddRenderPasses(ScriptableRenderer renderer, ref RenderingData renderingData)
         {
+#if !UNITY_2022_1_OR_NEWER
             fogPass.Setup(renderer.cameraColorTarget);
+#endif
+
             renderer.EnqueuePass(fogPass);
         }
     }
-    
-    
+
+
     public class FogPass : ScriptableRenderPass
     {
         private static readonly string shaderPath = "PostEffect/Fog";

--- a/URP-PSX/Assets/Scripts/Pixelation/PixelationRenderFeature.cs
+++ b/URP-PSX/Assets/Scripts/Pixelation/PixelationRenderFeature.cs
@@ -13,15 +13,23 @@ namespace PSX
             pixelationPass = new PixelationPass(RenderPassEvent.BeforeRenderingPostProcessing);
         }
 
+#if UNITY_2022_1_OR_NEWER
+        public override void SetupRenderPasses(ScriptableRenderer renderer, in RenderingData renderingData)
+        { pixelationPass.Setup(renderer.cameraColorTargetHandle); }
+#endif
+
         //ScripstableRendererFeature is an abstract class, you need this method
         public override void AddRenderPasses(ScriptableRenderer renderer, ref RenderingData renderingData)
         {
-            pixelationPass.Setup(renderer.cameraColorTarget);
+#if !UNITY_2022_1_OR_NEWER
+            ditheringPass.Setup(renderer.cameraColorTarget);
+#endif
+
             renderer.EnqueuePass(pixelationPass);
         }
     }
-    
-    
+
+
     public class PixelationPass : ScriptableRenderPass
     {
         private static readonly string shaderPath = "PostEffect/Pixelation";


### PR DESCRIPTION
Updated the render features to support Unity 2022.1+
![Screenshot_1](https://github.com/Kodrin/URP-PSX/assets/52583316/7c243d9e-daec-47bc-abae-d4d319acc2e6)

# What changed?
Specificaly, this.
```cs
public override void AddRenderPasses(ScriptableRenderer renderer, ref RenderingData renderingData)
{
       fogPass.Setup(renderer.cameraColorTarget); // <--- Borked.
       renderer.EnqueuePass(fogPass);
}
```

Should instead be:
```cs
#if UNITY_2022_1_OR_NEWER
        public override void SetupRenderPasses(ScriptableRenderer renderer, in RenderingData renderingData)
        { fogPass.Setup(renderer.cameraColorTargetHandle); }
#endif

        //ScripstableRendererFeature is an abstract class, you need this method
        public override void AddRenderPasses(ScriptableRenderer renderer, ref RenderingData renderingData)
        {
#if !UNITY_2022_1_OR_NEWER
            fogPass.Setup(renderer.cameraColorTarget);
#endif

            renderer.EnqueuePass(fogPass);
        }
```

This will ensure previous versions still function the same while versions post 2022.1 use the updated format and variables.